### PR TITLE
Add support for HAProxy LOCAL header

### DIFF
--- a/src/main/java/nl/thijsalders/spigotproxy/netty/NettyChannelInitializer.java
+++ b/src/main/java/nl/thijsalders/spigotproxy/netty/NettyChannelInitializer.java
@@ -52,7 +52,12 @@ public class NettyChannelInitializer extends ChannelInitializer<SocketChannel> {
                     String realaddress = message.sourceAddress();
                     int realport = message.sourcePort();
 
-                    SocketAddress socketaddr = new InetSocketAddress(realaddress, realport);
+                    // Use proxied client address from HAProxy PROXY header
+                    // Or use channel address for HAProxy LOCAL header
+                    // See: https://www.haproxy.org/download/2.4/doc/proxy-protocol.txt
+                    SocketAddress socketaddr = (realaddress != null)
+                        ? new InetSocketAddress(realaddress, realport)
+                        : channel.remoteAddress();
 
                     ChannelHandler handler = channel.pipeline().get("packet_handler");
                     addr.set(handler, socketaddr);


### PR DESCRIPTION
While the `PROXY` header is used for proxied connections, the `LOCAL` header is used for connections initiated from the proxy. This might happen when the proxy does a health check.

This is used in [`lazymc`](https://github.com/timvisee/lazymc) to poll the server state and to prepare client connections.

See: https://www.haproxy.org/download/2.4/doc/proxy-protocol.txt